### PR TITLE
Login/Signup/Logout Buttons are now functional

### DIFF
--- a/src/components/Login/check_login.tsx
+++ b/src/components/Login/check_login.tsx
@@ -6,13 +6,11 @@ async function checkLogin(): Promise<boolean> {
       let check = true
       await firebase.auth().onAuthStateChanged(function(user) {
         if (user) {
-          console.log("USER LOGGED IN!");
-          console.log("The user that logged in: ", user);
           check = true
         } else {
           // No user is signed in.
-          console.log("Not logged in!");
           check = false
+          return check;
         }
       });
       return check

--- a/src/components/Login/check_login.tsx
+++ b/src/components/Login/check_login.tsx
@@ -1,0 +1,24 @@
+import firebase from 'firebase';
+
+// TODO: pass input for user email and password during registration
+async function checkLogin(): Promise<boolean> {
+    try {
+      let check = true
+      await firebase.auth().onAuthStateChanged(function(user) {
+        if (user) {
+          console.log("USER LOGGED IN!");
+          console.log("The user that logged in: ", user);
+          check = true
+        } else {
+          // No user is signed in.
+          console.log("Not logged in!");
+          check = false
+        }
+      });
+      return check
+    } catch (error) {
+      return false
+    }
+  }
+
+export default checkLogin;

--- a/src/components/Login/login_form.tsx
+++ b/src/components/Login/login_form.tsx
@@ -1,7 +1,7 @@
 import firebase from 'firebase';
 
 // TODO: pass input for user email and password during registration
-async function loginUser(email: string, password: string): Promise<void>{
+async function loginUser(email: string, password: string): Promise<boolean>{
     await firebase.auth().signInWithEmailAndPassword(email, password).catch(function(error) {
       const errorCode = error.code;
       const errorMessage = error.message;
@@ -14,8 +14,10 @@ async function loginUser(email: string, password: string): Promise<void>{
     if (user) {
       console.log("User stuff: ", user.email);
       console.log("User ID: ", user.uid);
+      return true;
     } else {
-      // No user is signed in.
+      window.alert("Wrong email/password for login");
+      return false;
     }
 
 }

--- a/src/components/Login/logout_form.tsx
+++ b/src/components/Login/logout_form.tsx
@@ -1,0 +1,13 @@
+import firebase from 'firebase';
+
+// TODO: pass input for user email and password during registration
+async function logoutUser(): Promise<void>{
+    try {
+        await firebase.auth().signOut();
+        console.log("signed out!");
+    } catch (e){
+        console.log("Couldn't log out!");
+    } 
+}
+
+export default logoutUser;

--- a/src/components/NavBar/navbar_top.tsx
+++ b/src/components/NavBar/navbar_top.tsx
@@ -78,7 +78,8 @@ class NavbarTop extends React.Component<any, any> {
 
   handleLogout() {
     logoutUser();
-    this.setState({userLogged: checkLogin()});
+    this.setState({userLogged: false});
+    this.setState({userEmail: ""});
   }
 
   signUpClick() {

--- a/src/components/NavBar/navbar_top.tsx
+++ b/src/components/NavBar/navbar_top.tsx
@@ -10,9 +10,7 @@ import newUser from '../Signup/signup_form'
 import loginUser from '../Login/login_form'
 import firebase from 'firebase';
 import checkLogin from "../Login/check_login";
-import userEvent from "@testing-library/user-event";
-import { isThisTypeNode } from "typescript";
-
+import logoutUser from "../Login/logout_form";
 
 type state = { collapsed: boolean,
               signupCollapsed: boolean,
@@ -40,19 +38,24 @@ class NavbarTop extends React.Component<any, any> {
   getUserEmail(){
     firebase.auth().onAuthStateChanged((user) => {
       if (user) {
-        console.log("USER EMAIL SEEN");
-        console.log("The user in email: ", user.email);
         this.setState({userEmail: user.email});
       } else {
-        console.log("No user found")
         this.setState({userEmail: ""});
+        this.setState({userLogged: true});
       }
-    });
-    
+    });  
   }
   
   getUserStatus(){
-    this.setState({userLogged: checkLogin()});
+    firebase.auth().onAuthStateChanged((user) => {
+      if (user) {
+        // User logged in already or has just logged in.
+        this.setState({userLogged: false});
+      } else {
+        // User not logged in or has just logged out.
+        this.setState({userLogged: true});
+      }  
+    });
   }
 
   handleToggle() {
@@ -73,12 +76,27 @@ class NavbarTop extends React.Component<any, any> {
     this.setState({ signupCollapsed: false});
   }
 
+  handleLogout() {
+    logoutUser();
+    this.setState({userLogged: checkLogin()});
+  }
+
   signUpClick() {
+    this.setState({signupCollapsed: false});
+    this.setState({loginCollapsed: false});
     newUser(this.state.email, this.state.password);
   }
 
-  loginClick() {
-    loginUser(this.state.email, this.state.password);
+  async loginClick() {
+    this.setState({signupCollapsed: false});
+    this.setState({loginCollapsed: false});
+    const check = await loginUser(this.state.email, this.state.password);
+    if(check == false){
+      this.setState({userLogged: false});
+    } else {
+      this.setState({userLogged: false});
+    }
+    this.getUserEmail();
   }
 
   render() {
@@ -158,7 +176,7 @@ class NavbarTop extends React.Component<any, any> {
   userMenuShown = () => (
     <div className="dropdown-content">
       { this.state.userLogged ? this.state.userEmail : this.state.userEmail }
-      <button className="button dropdown-item" id="list_button" onClick={()=>this.handleLogin()}>Log Out</button>
+      <button className="button dropdown-item" id="list_button" onClick={()=>this.handleLogout()}>Log Out</button>
     </div>
   );
 
@@ -176,7 +194,7 @@ class NavbarTop extends React.Component<any, any> {
                                                  : this.state.userEmail }
               </div>
               <div className="buttons">
-                <button className={"button is-black is-outlined"} onClick={()=>this.handleSignup()}>Log out</button>
+                <button className={"button is-black is-outlined"} onClick={()=>this.handleLogout()}>Log out</button>
               </div>
     </div>
   );

--- a/src/components/NavBar/navbar_top.tsx
+++ b/src/components/NavBar/navbar_top.tsx
@@ -8,6 +8,11 @@ import form_logo from '../../assets/form_icon.png'
 import apartment_logo from '../../assets/apartment_icon.png'
 import newUser from '../Signup/signup_form'
 import loginUser from '../Login/login_form'
+import firebase from 'firebase';
+import checkLogin from "../Login/check_login";
+import userEvent from "@testing-library/user-event";
+import { isThisTypeNode } from "typescript";
+
 
 type state = { collapsed: boolean,
               signupCollapsed: boolean,
@@ -25,10 +30,30 @@ class NavbarTop extends React.Component<any, any> {
                   signupCollapsed: false,
                   loginCollapsed: false,
                   email: "",
-                  password: "" };
+                  password: "",
+                  userLogged: this.getUserStatus(),
+                  userEmail: this.getUserEmail()
+    }
     this.handleChange = this.handleChange.bind(this);
   }
+
+  getUserEmail(){
+    firebase.auth().onAuthStateChanged((user) => {
+      if (user) {
+        console.log("USER EMAIL SEEN");
+        console.log("The user in email: ", user.email);
+        this.setState({userEmail: user.email});
+      } else {
+        console.log("No user found")
+        this.setState({userEmail: ""});
+      }
+    });
+    
+  }
   
+  getUserStatus(){
+    this.setState({userLogged: checkLogin()});
+  }
 
   handleToggle() {
     this.setState({ collapsed: !this.state.collapsed });
@@ -66,7 +91,7 @@ class NavbarTop extends React.Component<any, any> {
               We-Locate
             </h1>
           </div>
-           
+
           <div className={"navbar-burger dropdown is-right" + (this.state.collapsed ? "" : " is-active")} onClick={() => this.handleToggle()} aria-label="menu"
             aria-haspopup="true" aria-controls="dropdown-menu" aria-expanded="false">
             <div className="dropdown-trigger">
@@ -77,21 +102,13 @@ class NavbarTop extends React.Component<any, any> {
               
             </div>
             <div className="dropdown-menu" id="dropdown-menu" role="menu">
-                <div className="dropdown-content">
-                  <button className="button dropdown-item" id="list_button" onClick={()=>this.handleSignup()}>Sign Up</button>
-                  <button className="button dropdown-item" id="list_button" onClick={()=>this.handleLogin()}>Login</button>
-                </div>
+              { this.state.userLogged ? <this.menuShown /> : <this.userMenuShown /> }
             </div>
           </div>
         </div>
         <div id="navbarButtons" className="navbar-menu">
           <div className="navbar-end">
-            <div className="navbar-item">
-              <div className="buttons">
-                <button className={"button is-black is-outlined"} onClick={()=>this.handleSignup()}>Sign Up</button>
-                <button className="button is-black is-outlined" onClick={()=>this.handleLogin()}>Login</button>
-              </div>
-            </div>
+            { this.state.userLogged ? <this.buttonsShown /> : <this.userShown /> }
           </div>
         </div>
       </nav> 
@@ -137,6 +154,41 @@ class NavbarTop extends React.Component<any, any> {
       </section>
    );
   }
+
+  userMenuShown = () => (
+    <div className="dropdown-content">
+      { this.state.userLogged ? this.state.userEmail : this.state.userEmail }
+      <button className="button dropdown-item" id="list_button" onClick={()=>this.handleLogin()}>Log Out</button>
+    </div>
+  );
+
+  menuShown = () => (
+    <div className="dropdown-content">
+      <button className="button dropdown-item" id="list_button" onClick={()=>this.handleSignup()}>Sign Up</button>
+      <button className="button dropdown-item" id="list_button" onClick={()=>this.handleLogin()}>Login</button>
+    </div>
+  );
+
+  userShown = () => (
+    <div className="navbar-item">
+              <div id="Username">
+                Welcome, { this.state.userLogged ? this.state.userEmail 
+                                                 : this.state.userEmail }
+              </div>
+              <div className="buttons">
+                <button className={"button is-black is-outlined"} onClick={()=>this.handleSignup()}>Log out</button>
+              </div>
+    </div>
+  );
+
+  buttonsShown = () => (
+  <div className="navbar-item">
+    <div className="buttons">
+      <button className={"button is-black is-outlined"} onClick={()=>this.handleSignup()}>Sign Up</button>
+      <button className="button is-black is-outlined" onClick={()=>this.handleLogin()}>Login</button>
+    </div>
+  </div>
+  );
 
   Signup = () => (
     <div className="box column is-quarter is-pulled-right has-background-white">

--- a/src/components/Signup/signup_form.tsx
+++ b/src/components/Signup/signup_form.tsx
@@ -19,18 +19,18 @@ async function newUser(email: string, password: string): Promise<void>{
       window.alert("Error: " + errorCode + errorMessage);
       return;
     });
-    window.alert( "Creating user!");
+    window.alert( "Creating user in database!");
     await db.collection("Users").doc(uid).set({
       name: email,
       password: password
     })
     .then(function() {
-      window.alert("Successfully Checked In!")
+      window.alert("Doc completion notification.")
     })
     .catch(function(error) {
       console.error("Error adding user: ", error);
     });
-    
+    window.alert("Done w/acc creation.")
     
 }
 


### PR DESCRIPTION
- Signup will do nothing with invalid data except give a couple (irrelevant right now TODO) window popups
- Signup will also login user with the new account due to onauthchange
- Signup creates user document in cloud firestore and provides user email in auth credentials
- Log in does nothing with wrong information (Error display TODO);
- Log in logs user in and displays their email if successfully logged in on the front page, along with a logout button
- Logout logs user back out, erasing their email stored for display and showing the signup/login buttons again.
- Logout, naturally, can't really have easily testable errors so I haven't tested beyond it working fine in a minimized window.